### PR TITLE
setup.py - fix Python 3 encoding issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import codecs
 import os
 import sys
 
@@ -7,11 +8,14 @@ from setuptools import setup, find_packages
 
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 
+with codecs.open('README.rst', 'r', 'utf-8') as f:
+    long_description = f.read()
+
 setup(
     name="libzbar-cffi",
     version="0.2.0",
     description="Efficient cffi-based bindings for the zbar QR decoder (Py2, Py3, and PyPy)",
-    long_description=open("README.rst", "rt").read(),
+    long_description=long_description,
     url="https://github.com/wolever/libzbar-cffi",
     author="David Wolever",
     author_email="david@wolever.net",


### PR DESCRIPTION
setup.py - fix Python 3 encoding issues

README.rst features unicode characters (specifically, an ellipsis, '…'). It thus fails to install on Python 3 in environments where the `LANG` environment variable is not set, or not set to `utf8`. I found this is the case when `pip` is run under Ansible, since no environment vars are set.

Fix this by not making Python 3 guess the encoding of the file and instead being explicit that it's UTF-8 by using `codecs.open()`.

Test:
1. before:

``` sh
(virtualenv:test) $ LANG= python setup.py install
Traceback (most recent call last):
  File "setup.py", line 14, in <module>
    long_description=open("README.rst", "rt").read(),
  File "/Users/adamj/.virtualenvs/test/bin/../lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1623: ordinal not in range(128)
```
1. after:

``` sh
(virtualenv:test) $ LANG= python setup.py install

...

Using /Users/adamj/Documents/Projects/libzbar-cffi/.eggs/pycparser-2.14-py3.5.egg
Finished processing dependencies for libzbar-cffi==0.2.0
```
